### PR TITLE
Fk/gpsd max nmea packet size

### DIFF
--- a/drivers/driver_nmea0183.c
+++ b/drivers/driver_nmea0183.c
@@ -3733,7 +3733,6 @@ static gps_mask_t processPQTMINS(int count, char *field[],
     session->gpsdata.attitude.roll = safe_atof(field[9]);
     session->gpsdata.attitude.pitch = safe_atof(field[10]);
     session->gpsdata.attitude.heading = safe_atof(field[11]);
-    mask |= ATTITUDE_SET;
 
     switch (soltype) {
     case 0: /* DR not ready; roll and pitch ready */

--- a/drivers/driver_nmea0183.c
+++ b/drivers/driver_nmea0183.c
@@ -3684,8 +3684,11 @@ static gps_mask_t processSTI(int count, char *field[],
  *     180.0/0.0 = N
  *    +90.0 = East
  *    -90.0 = West
- *
- * Example: $PQTMINS,1918570,1,50.047965000,19.958976200,250.544000,,,,-0.584531,18.488698,33.769880*4B
+ * 
+ * Example:
+ * $PQTMINS,1918570,1,50.047965000,19.958976200,250.544000,,,,-0.584531,18.488698,33.769880*4B
+ * or
+ * $PQTMINS,1313867,2,50.047475906,19.959435690,263.702605,0.000000,0.000000,0.000000,-1.770574,6.623167,27.461326*61
  *
  */
 static gps_mask_t processPQTMINS(int count, char *field[],
@@ -3748,7 +3751,7 @@ static gps_mask_t processPQTMINS(int count, char *field[],
         break;
     case 3: /* DR only mode */
         session->newdata.status  = STATUS_DR;
-        session->newdata.mode = MODE_2D;    
+        session->newdata.mode = MODE_2D;
         mask |= REPORT_IS;
         break;
     default:

--- a/include/gpsd.h
+++ b/include/gpsd.h
@@ -142,8 +142,11 @@ extern "C" {
  * The Trimble BX-960 receiver emits a 91-character GGA message.
  * The current hog champion is the Skytraq S2525F8 which emits
  * a 100-character PSTI message.
+ *
+ * Quectel LC29D emits PQTMINS which can have size of 115 characters.
+ * This size is achieved only when the VEL_N, VEL_E, VEL_D fields are filled in.
  */
-#define NMEA_MAX        102     /* max length of NMEA sentence */
+#define NMEA_MAX        118     /* max length of NMEA sentence */
 #define NMEA_MAX_FLD    100     // max fields in an NMEA sentence
 #define NMEA_BIG_BUF    (2*NMEA_MAX+1)  /* longer than longest NMEA sentence */
 


### PR DESCRIPTION
Quectel LC29D emits a packet in form
$PQTMINS,1313192,2,50.047475906,19.959435690,263.702605,0.000000,0.000000,0.000000,-1.770586,6.626699,27.461326*6C
which is 115 characters long, more than allowed by NMEA and gpsd.
Increase the limit to avoid dropping the message and allow for 10Hz
updates under all conditions.