### PR TITLE
nmea0183: Create gpsd report on every PQTMGPS message

### DIFF
--- a/drivers/driver_nmea0183.c
+++ b/drivers/driver_nmea0183.c
@@ -3861,6 +3861,7 @@ static gps_mask_t processPQTMGPS(int count, char *field[],
 
     session->newdata.mode = MODE_3D;
     mask |= MODE_SET;
+    mask |= REPORT_IS;
 
     GPSD_LOG( LOG_DATA, &session->context->errout,
         "PQTMGPS: time=%d, lat=%.9f lon=%.9f",


### PR DESCRIPTION
Without REPORT_IS, creation of report depends on the sequence of incoming messages. Make it independent by triggering a report on every PQTMGPS (raw GNSS-only position).